### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -10,16 +10,16 @@
 # Methods and Functions (KEYWORD2)
 #######################################
 
-finished            KEYWORD2
-setChannel	        KEYWORD2
-setChannels         KEYWORD2
-setPrescaler	      KEYWORD2
+finished	KEYWORD2
+setChannel	KEYWORD2
+setChannels	KEYWORD2
+setPrescaler	KEYWORD2
 setLeftAlignResult	KEYWORD2
-setAutoTrigger	    KEYWORD2
-setTriggerSource    KEYWORD2
-setBuffer           KEYWORD2
-next                KEYWORD2
-enableDigitalInputs KEYWORD2
+setAutoTrigger	KEYWORD2
+setTriggerSource	KEYWORD2
+setBuffer	KEYWORD2
+next	KEYWORD2
+enableDigitalInputs	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords